### PR TITLE
Add option to enable coerce types

### DIFF
--- a/src/backend.test.ts
+++ b/src/backend.test.ts
@@ -47,6 +47,30 @@ describe('OpenAPIBackend', () => {
         get: {
           operationId: 'getPetById',
           responses,
+          parameters: [
+            {
+              name: 'id',
+              in: 'path',
+              required: true,
+              schema: {
+                type: 'string',
+              },
+            },
+            {
+              name: 'breed',
+              in: 'query',
+              schema: {
+                type: 'string',
+              },
+            },
+            {
+              name: 'age',
+              in: 'query',
+              schema: {
+                type: 'integer',
+              },
+            },
+          ],
         },
         put: {
           operationId: 'replacePetById',
@@ -465,6 +489,52 @@ describe('OpenAPIBackend', () => {
 
         expect(mockHandler).toBeCalled();
       });
+    });
+  });
+
+  describe('types coercion', () => {
+    test('coerces query types', async () => {
+      const api = new OpenAPIBackend({ definition, coerceTypes: true });
+      const dummyHandler = jest.fn((context, req, ...rest) => req);
+      api.register('getPetById', dummyHandler);
+      await api.init();
+
+      const request = {
+        method: 'get',
+        path: '/pets/1',
+        headers: {},
+        query: {
+          breed: 'corgi',
+          age: '5',
+        },
+      };
+
+      const res = await api.handleRequest(request);
+      expect(dummyHandler).toHaveBeenCalledTimes(1);
+
+      expect(res.query).toStrictEqual({ breed: 'corgi', age: 5 });
+    });
+
+    test('coerces query types disabled by default', async () => {
+      const api = new OpenAPIBackend({ definition });
+      const dummyHandler = jest.fn((context, req, ...rest) => req);
+      api.register('getPetById', dummyHandler);
+      await api.init();
+
+      const request = {
+        method: 'get',
+        path: '/pets/1',
+        headers: {},
+        query: {
+          breed: 'corgi',
+          age: '5',
+        },
+      };
+
+      const res = await api.handleRequest(request);
+      expect(dummyHandler).toHaveBeenCalledTimes(1);
+
+      expect(res.query).toStrictEqual({ breed: 'corgi', age: '5' });
     });
   });
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -47,8 +47,10 @@ export interface Request {
       }
     | string;
   body?: AnyRequestBody;
+  params?: {
+    [key: string]: string;
+  };
 }
-
 
 export interface ParsedRequest<
   RequestBody = AnyRequestBody,

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -125,6 +125,7 @@ export class OpenAPIValidator<D extends Document = Document> {
   public ajvOpts: AjvOpts;
   public lazyCompileValidators: boolean;
   public customizeAjv: AjvCustomizer | undefined;
+  public coerceTypes: boolean;
 
   public requestValidators: { [operationId: string]: ValidateFunction[] | null };
   public responseValidators: { [operationId: string]: ValidateFunction | null };
@@ -141,6 +142,7 @@ export class OpenAPIValidator<D extends Document = Document> {
    * @param {object} opts.ajvOpts - default ajv constructor opts (default: { unknownFormats: 'ignore' })
    * @param {OpenAPIRouter} opts.router - passed instance of OpenAPIRouter. Will create own child if no passed
    * @param {boolean} opts.lazyCompileValidators - skips precompiling Ajv validators and compiles only when needed
+   * @param {boolean} opts.coerceTypes - coerce types in request query and path parameters
    * @memberof OpenAPIRequestValidator
    */
   constructor(opts: {
@@ -149,6 +151,7 @@ export class OpenAPIValidator<D extends Document = Document> {
     router?: OpenAPIRouter<D>;
     lazyCompileValidators?: boolean;
     customizeAjv?: AjvCustomizer;
+    coerceTypes?: boolean;
   }) {
     this.definition = opts.definition;
     this.ajvOpts = {
@@ -157,6 +160,7 @@ export class OpenAPIValidator<D extends Document = Document> {
     };
 
     this.customizeAjv = opts.customizeAjv;
+    this.coerceTypes = opts.coerceTypes || false;
 
     // initalize router
     this.router = opts.router || new OpenAPIRouter({ definition: this.definition });
@@ -309,6 +313,9 @@ export class OpenAPIValidator<D extends Document = Document> {
       validate(parameters);
       if (validate.errors) {
         result.errors.push(...validate.errors);
+      } else if (this.coerceTypes) {
+        req.query = parameters.query;
+        req.params = parameters.path;
       }
     }
 


### PR DESCRIPTION
This change adds a new option 'coerceTypes' that will enable coerce typing of request query and path parameters. It is off by default and can be enabled if validate is also enabled.

Fixes #554 and supersede #571.