### PR TITLE
fix: honor optional request bodies during validation

### DIFF
--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -497,6 +497,7 @@ describe.each([{}, { lazyCompileValidators: true }])('OpenAPIValidator with opts
                   operationId: 'createPet',
                   responses: { 200: { description: 'ok' } },
                   requestBody: {
+                    required: true,
                     content: {
                       'application/json': {
                         schema: petSchema,
@@ -514,6 +515,19 @@ describe.each([{}, { lazyCompileValidators: true }])('OpenAPIValidator with opts
                       },
                       'application/xml': {
                         example: '<Pet><name>string</name></Pet>',
+                      },
+                    },
+                  },
+                },
+              },
+              '/optional-pets': {
+                post: {
+                  operationId: 'createOptionalPet',
+                  responses: { 200: { description: 'ok' } },
+                  requestBody: {
+                    content: {
+                      'application/json': {
+                        schema: petSchema,
                       },
                     },
                   },
@@ -640,6 +654,27 @@ describe.each([{}, { lazyCompileValidators: true }])('OpenAPIValidator with opts
         });
         expect(valid.errors).toHaveLength(2);
         expect(valid.errors && valid.errors[0].keyword).toBe('parse');
+      });
+
+      test('passes validation when optional requestBody with one media type is omitted', async () => {
+        const valid = validator.validateRequest({
+          path: '/optional-pets',
+          method: 'post',
+          headers,
+        });
+        expect(valid.errors).toBeFalsy();
+      });
+
+      test('fails validation when optional requestBody with one media type is provided but invalid', async () => {
+        const valid = validator.validateRequest({
+          path: '/optional-pets',
+          method: 'post',
+          headers,
+          body: {
+            age: 40,
+          },
+        });
+        expect(valid.errors).toHaveLength(1);
       });
 
       test('allows non-json data when application/json is not the only allowed media type', async () => {

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -578,8 +578,7 @@ export class OpenAPIValidator<D extends Document = Document> {
           },
         };
         requestBodySchema.required = [];
-        if (_.keys(requestBody.content).length === 1) {
-          // if application/json is the only specified format, it's required
+        if (requestBody.required) {
           requestBodySchema.required.push('requestBody');
         }
 


### PR DESCRIPTION
This fixes request validation for operations that define a `requestBody` without setting `required: true`. The validator was marking `requestBody` as required whenever the operation had exactly one content type, so an omitted optional body failed with `must have required property 'requestBody'`.

What changed:
- Only add `requestBody` to the generated required list when `requestBody.required` is true.
- Added regression coverage for an optional single-media-type body being omitted.
- Kept validation for an invalid optional body when one is provided.

Checked:
- `npm test -- src/validation.test.ts --runInBand`
- `npm run build`
- `npm run lint`
- `./node_modules/.bin/prettier --check src/validation.ts src/validation.test.ts`
- `npm test -- --runInBand`

Fixes #817.
Fixes #292.