### PR TITLE
docs: add vulnerability disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a vulnerability
 
-Please report suspected security vulnerabilities privately. Email **viljami@viljami.io** with `SECURITY` in the subject line. Do not open a public GitHub issue for an unpatched vulnerability.
+Please report suspected security vulnerabilities privately. Email **support@openapistack.co** with `SECURITY` in the subject line. Do not open a public GitHub issue for an unpatched vulnerability.
 
 Please include, where possible:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report suspected security vulnerabilities privately. Email **viljami@viljami.io** with `SECURITY` in the subject line. Do not open a public GitHub issue for an unpatched vulnerability.
+
+Please include, where possible:
+
+- the affected package and version;
+- a clear description of the vulnerability and its potential impact;
+- reproduction steps or a minimal proof of concept;
+- any relevant logs, configuration, or environment details; and
+- whether the issue is publicly known or being actively exploited.
+
+Please avoid including secrets or personal data in the report. If sensitive material is necessary, ask for a secure transfer method first.
+
+## What to expect
+
+We will acknowledge receipt as soon as practical, investigate in good faith, and keep the reporter informed when there is meaningful progress. We will coordinate disclosure with the reporter where possible, including credit if requested. There is no guaranteed response or remediation deadline.
+
+## Scope and safe harbor
+
+This policy covers security vulnerabilities in the code maintained in this repository and released versions of `openapi-backend`. Do not test against systems or data that you do not own or have explicit permission to assess, and do not intentionally access, modify, or retain data belonging to others.
+
+We ask security researchers acting in good faith to avoid service disruption, privacy violations, and destructive testing. We will not pursue legal action for good-faith research that follows this policy, stays within scope, and stops when a vulnerability is confirmed.
+
+This is a voluntary vulnerability-disclosure policy. It does not grant permission to test third-party systems and does not replace any legal or regulatory obligation that may apply.


### PR DESCRIPTION
## Summary

- add a one-page `SECURITY.md` for reporting suspected vulnerabilities
- document report contents, coordinated disclosure, scope, and good-faith research expectations
- keep the policy voluntary and avoid promising a remediation SLA

This is documentation only; no runtime code changed.
